### PR TITLE
Adding teensy 3.x support

### DIFF
--- a/I2CFunctions.h
+++ b/I2CFunctions.h
@@ -2,7 +2,10 @@
 #define I2C_FUNCTIONS_H
 
 #include <Arduino.h>
-#if defined(__MK20DX256__)|| defined(__MK20DX128__)
+
+// For more defines for Teensy (granularity), see: 
+// https://arduino.stackexchange.com/questions/21137/arduino-how-to-get-the-board-type-in-code 
+#if defined(TEENSYDUINO)
 #include <i2c_t3.h>
 #else
 #include <Wire.h>

--- a/I2CFunctions.h
+++ b/I2CFunctions.h
@@ -2,8 +2,11 @@
 #define I2C_FUNCTIONS_H
 
 #include <Arduino.h>
-// #include <Wire.h>
+#if defined(__MK20DX256__)|| defined(__MK20DX128__)
 #include <i2c_t3.h>
+#else
+#include <Wire.h>
+#endif
 
 #define STOP_CONDITION_I2C true
 class I2CFunctions {

--- a/I2CFunctions.h
+++ b/I2CFunctions.h
@@ -2,7 +2,8 @@
 #define I2C_FUNCTIONS_H
 
 #include <Arduino.h>
-#include <Wire.h>
+// #include <Wire.h>
+#include <i2c_t3.h>
 
 #define STOP_CONDITION_I2C true
 class I2CFunctions {

--- a/LidarController.h
+++ b/LidarController.h
@@ -3,7 +3,8 @@
 
 #include "I2CFunctions.h"
 #include "LidarObject.h"
-#include <Wire.h>
+// #include <Wire.h>
+#include <i2c_t3.h>
 
 // Wait between I2C transactions in µs
 // One bit every 10µs (2.5µs in 400kHz)
@@ -312,13 +313,15 @@ class LidarController {
       if(biasCorrection) nack = I2C.write(lidars[Lidar]->address, REG_ACQ_COMMAND, DATA_MEASURE_WITH_BIAS);
       else nack = I2C.write(lidars[Lidar]->address, REG_ACQ_COMMAND, DATA_MEASURE_WITHOUT_BIAS);
       shouldIncrementNack(Lidar, nack);
+	  return nack;
     };
 
     /*******************************************************************************
       distance:
         - Read the measured value from data registers
     *******************************************************************************/
-    uint8_t distance(uint8_t Lidar, int * data) {
+    //uint8_t distance(uint8_t Lidar, int * data) {
+	uint8_t distance(uint8_t Lidar, short * data) {
       uint8_t distanceArray[2];
       uint8_t nackCatcher = I2C.readWord(lidars[Lidar]->address, MEASURED_VALUE_REGISTER, distanceArray);
       shouldIncrementNack(Lidar, nackCatcher);
@@ -402,7 +405,7 @@ class LidarController {
       We could use the async() method in ACQUISITION_DONE, but it would need to spin
       one time more before starting the acquisition again
     *******************************************************************************/
-    uint8_t distanceAndAsync(uint8_t Lidar, int * data) {
+    uint8_t distanceAndAsync(uint8_t Lidar, short * data) {
       uint8_t nackCatcher = distance(Lidar, data);
       // if error reading the value, try ONCE again
       if (nackCatcher)

--- a/LidarController.h
+++ b/LidarController.h
@@ -321,7 +321,7 @@ class LidarController {
         - Read the measured value from data registers
     *******************************************************************************/
     //uint8_t distance(uint8_t Lidar, int * data) {
-	uint8_t distance(uint8_t Lidar, short * data) {
+	uint8_t distance(uint8_t Lidar, int16_t * data) {
       uint8_t distanceArray[2];
       uint8_t nackCatcher = I2C.readWord(lidars[Lidar]->address, MEASURED_VALUE_REGISTER, distanceArray);
       shouldIncrementNack(Lidar, nackCatcher);
@@ -356,7 +356,7 @@ class LidarController {
         This has to be worked on, this is the original implementation without the 
           blocking architecture
     *******************************************************************************/
-    int velocity(uint8_t Lidar, int * data) {
+    int16_t velocity(uint8_t Lidar, int16_t * data) {
       // Set in velocity mode
       I2C.write(lidars[Lidar]->address, REG_ACQ_CONFIG, DATA_VELOCITY_MODE_DATA);
       //  Write 0x04 to register 0x00 to start getting distance readings
@@ -365,7 +365,7 @@ class LidarController {
       uint8_t velocityArray[1];
       uint8_t nack = I2C.readByte(lidars[Lidar]->address, REG_VELOCITY, velocityArray);
 
-      return((int)((char)velocityArray[0]));
+      return((int16_t)((char)velocityArray[0]));
     };
 
     /*******************************************************************************
@@ -405,7 +405,7 @@ class LidarController {
       We could use the async() method in ACQUISITION_DONE, but it would need to spin
       one time more before starting the acquisition again
     *******************************************************************************/
-    uint8_t distanceAndAsync(uint8_t Lidar, short * data) {
+    uint8_t distanceAndAsync(uint8_t Lidar, int16_t * data) {
       uint8_t nackCatcher = distance(Lidar, data);
       // if error reading the value, try ONCE again
       if (nackCatcher)

--- a/LidarController.h
+++ b/LidarController.h
@@ -3,9 +3,6 @@
 
 #include "I2CFunctions.h"
 #include "LidarObject.h"
-// #include <Wire.h>
-#include <i2c_t3.h>
-
 // Wait between I2C transactions in µs
 // One bit every 10µs (2.5µs in 400kHz)
 // Wait at least 5 bits to wait for slave answer

--- a/LidarObject.h
+++ b/LidarObject.h
@@ -1,6 +1,4 @@
 #include <Arduino.h>
-//#include <Wire.h>
-#include <i2c_t3.h>
 #include "I2CFunctions.h"
 // We got a Lidar object per laser. 
 

--- a/LidarObject.h
+++ b/LidarObject.h
@@ -1,5 +1,6 @@
 #include <Arduino.h>
-#include <Wire.h>
+//#include <Wire.h>
+#include <i2c_t3.h>
 #include "I2CFunctions.h"
 // We got a Lidar object per laser. 
 
@@ -128,6 +129,7 @@ class LidarObject {
 *******************************************************************************/
     bool resetNacksCount(){
       nacksCount = 0;
+	  return 1;
     };
 
 /*******************************************************************************

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Introduction
 --------------
 This library tends to improve the **efficiency** and the **robustness** of the poor original acquisition library. It is originally released for the LidarLite v2 (deprecated) and compatible with the LidarLite v3 (release from Garmin) lasermeter.
 
-This fork of the library has been modified to work on a Teensy 3.x (3.5) 32-bit board. It requires that you have i2c_t3.h library (https://github.com/nox771/i2c_t3) installed. 
+The Teensy 3.x (3.5) 32-bit board support has been added by [adam-sampson](http://github.com/adam-sampson). If you use it, replace `#include <Wire.h>` by `#include <i2c_t3.h>` in the examples and install the [i2c_t3 library](https://github.com/nox771/i2c_t3)
 
 Improvements over the original library
 --------------------
@@ -446,3 +446,4 @@ Pull requests are welcome :D
 Credits 
 ------
 * Alexis Paques (alexis[dot]paques[at]gmail[dot]com)
+* Adam Sampson

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Introduction
 --------------
 This library tends to improve the **efficiency** and the **robustness** of the poor original acquisition library. It is originally released for the LidarLite v2 (deprecated) and compatible with the LidarLite v3 (release from Garmin) lasermeter.
 
+This fork of the library has been modified to work on a Teensy 3.x (3.5) 32-bit board. It requires that you have i2c_t3.h library (https://github.com/nox771/i2c_t3) installed. 
+
 Improvements over the original library
 --------------------
 - *Asynchronous acquisition*

--- a/example/Teensy/Teensy.ino
+++ b/example/Teensy/Teensy.ino
@@ -1,0 +1,47 @@
+#include <Arduino.h>
+#include <i2c_t3.h>
+#include <I2CFunctions.h> 
+#include <LidarObject.h>
+#include <LidarController.h>
+
+#define WIRE400K true
+// Trigger pin, can be unplugged
+#define Z1_LASER_TRIG 11
+// Enable pin, IMPORTANT
+#define Z1_LASER_EN 12
+// Mode pin, can be unplugged
+#define Z1_LASER_PIN 13
+//Define address of lasers
+//Thoses are written during initialisation
+// default address : 0x62
+#define Z1_LASER_AD 0x6E
+
+#define NUMBER_OF_LASERS 1
+
+// Create lasers
+static LidarController Controller;
+static LidarObject LZ1;
+
+void setup()
+{
+  Serial.begin(115200);
+  // Configure lasers
+  LZ1.begin(Z1_LASER_EN, Z1_LASER_PIN, Z1_LASER_TRIG, Z1_LASER_AD, 2, DISTANCE, 'A');
+  LZ1.setCallbackDistance(&distance_callback);
+  // Add the laser to the Controller
+  Controller.add(&LZ1, 0);
+
+  delay(100);
+  Controller.begin(WIRE400K);
+  delay(100);
+}
+
+void distance_callback(LidarObject* self){
+   Serial.println(self->distance);
+}
+
+void loop()
+{
+  Controller.spinOnce();
+  // Rest of your non blocking application. 
+}


### PR DESCRIPTION
This PR adds a granularity for the I2C library, it adds `i2c_t3` library for the Teensy boards.

@adam-sampson Can you confirm that this stays working on the Teensy 3.x? Especially to ensure the `#if defined(TEENSYDUINO)` selects properly the Teensy boards on the IDE you use.

@Serveurperso Wasn't it a Teensy you were using? This could interest you.
