### PR TITLE
Remove double declaration.

### DIFF
--- a/I2CFunctions.h
+++ b/I2CFunctions.h
@@ -172,8 +172,6 @@ class I2CFunctions {
     };
 };
 
-
-I2CFunctions I2C;
 extern I2CFunctions I2C;
 
 #endif


### PR DESCRIPTION
On a SAMD architecture we are getting the following compilation error:

```
multiple definition of `I2C'
```

In this PR we remove the double declaration. I'm not sure whether this breaks the library on other architectures?